### PR TITLE
🔧 Update gemspec description & min ruby version

### DIFF
--- a/percy-selenium.gemspec
+++ b/percy-selenium.gemspec
@@ -8,10 +8,12 @@ Gem::Specification.new do |spec|
   spec.version       = Percy::VERSION
   spec.authors       = ['Perceptual Inc.']
   spec.email         = ['team@percy.io']
-  spec.summary       = %q{Percy}
+  spec.summary       = %q{Percy visual testing for Ruby Selenium}
   spec.description   = %q{}
   spec.homepage      = ''
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 2.3.0'
+
 
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/percy/percy-selenium-ruby/issues',


### PR DESCRIPTION
## What is this?

The current ruby gems page looks a little sparce (no description, missing ruby version)

![image](https://user-images.githubusercontent.com/2072894/116291957-cccfd580-a75a-11eb-9f1b-b06a5df678ab.png)

## Approach

So let's fix that! Doesn't look like it's common (or possible?) to put the README contents as the description. So this just updates the description to our usual byline. 