### PR TITLE
📝 Update snapshot options docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,4 @@ $ percy exec -- [ruby test command]
 
 - `driver` (**required**) - A selenium-webdriver driver instance
 - `name` (**required**) - The snapshot name; must be unique to each snapshot
-- `options` - Additional snapshot options (overrides any project options)
-  - `widths` - An array of widths to take screenshots at
-  - `min_height` - The minimum viewport height to take screenshots at
-  - `percy_css` - Percy specific CSS only applied in Percy's rendering environment
-  - `request_headers` - Headers that should be used during asset discovery
-  - `enable_javascript` - Enable JavaScript in Percy's rendering environment
+- `options` - [See per-snapshot configuration options](https://docs.percy.io/docs/cli-configuration#per-snapshot-configuration)


### PR DESCRIPTION
## What is this?

With our snapshot options being standardized / the same across all SDKs, it'd be more future proof to link to a single snapshot options doc. 