### PR TITLE
CI Add validation for branch input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,15 @@ jobs:
         ruby: ['2.6', '2.7']
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          text: ${{ github.event.inputs.branch }}
+          regex: '^[a-zA-Z0-9_/\-]+$'
+      - name: Break on invalid branch name
+        run: exit 1
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Adds validation for branch provided from workflow dispatch input to avoid injection attacks. See https://github.com/percy/cli/pull/1244