### PR TITLE
Fix for uninitialized capybara responsive snapshot capture

### DIFF
--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'version'
 require 'net/http'
 require 'selenium-webdriver'
+require 'capybara'
 
 module Percy
   CLIENT_INFO = "percy-selenium-ruby/#{VERSION}".freeze

--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -3,7 +3,6 @@ require 'json'
 require 'version'
 require 'net/http'
 require 'selenium-webdriver'
-require 'capybara'
 
 module Percy
   CLIENT_INFO = "percy-selenium-ruby/#{VERSION}".freeze
@@ -47,7 +46,8 @@ module Percy
   end
 
   def self.get_browser_instance(driver)
-    if driver.is_a?(Capybara::Session)
+    # this means it is a capybara session
+    if driver.respond_to?(:driver) && driver.driver.respond_to?(:browser)
       return driver.driver.browser.manage
     end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Percy
-  VERSION = '1.1.0-beta.0'.freeze
+  VERSION = '1.1.0-beta.2'.freeze
 end

--- a/percy-selenium.gemspec
+++ b/percy-selenium.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'selenium-webdriver', '>= 4.0.0.beta1'
+  spec.add_runtime_dependency 'capybara', '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/percy-selenium.gemspec
+++ b/percy-selenium.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'selenium-webdriver', '>= 4.0.0.beta1'
-  spec.add_runtime_dependency 'capybara', '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
- While running session with responsive snapshot capture getting error that capybara is not initialised. reason it was not caught in tests/testing we are using  capybara for our tests and in our test script as well. fixing this error