### PR TITLE
updating actions/cache: v3 for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           ruby-version: 2.6
           bundler-cache: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "./vendor/bundle"
           key: v1/${{ runner.os }}/ruby-2.6/${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
updating actions/cache: v3 for release as v2 is deprecated