### PR TITLE
fix: force UTF-8 on @percy/dom script + serialized DOM (1.1.3-beta.1)

### DIFF
--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -85,6 +85,14 @@ module Percy
         get_serialized_dom(driver, options, percy_dom_script: percy_dom_script)
       end
 
+      # selenium-webdriver returns execute_script string results tagged
+      # ASCII-8BIT (binary), though their bytes are valid UTF-8 (the WebDriver
+      # wire protocol is UTF-8). Without this, JSON-encoding the payload raises
+      # Encoding::UndefinedConversionError on any multibyte byte (e.g. "\xE2"
+      # from an em-dash/emoji/CSSOM). Relabel as UTF-8 (no transcode) so the
+      # snapshot posts for non-ASCII pages.
+      dom_snapshot = force_utf8(dom_snapshot)
+
       # Strip `readiness` before POSTing -- SDK-local config that the CLI
       # already has via healthcheck.
       post_options = options.reject { |k, _| k.to_s == 'readiness' }
@@ -223,6 +231,24 @@ module Percy
 
     dom_snapshot['cookies'] = get_browser_instance(driver).all_cookies
     dom_snapshot
+  end
+
+  # Recursively relabel every String in the serialized-DOM structure as UTF-8.
+  # selenium-webdriver hands back execute_script results as ASCII-8BIT; the
+  # bytes are already valid UTF-8, so force_encoding (not encode) is correct --
+  # it relabels without transcoding. Prevents Encoding::UndefinedConversionError
+  # when the payload is JSON-encoded for pages with non-ASCII content.
+  def self.force_utf8(obj)
+    case obj
+    when String
+      obj.encoding == Encoding::UTF_8 ? obj : obj.dup.force_encoding(Encoding::UTF_8)
+    when Hash
+      obj.each_with_object({}) { |(k, v), memo| memo[k] = force_utf8(v) }
+    when Array
+      obj.map { |v| force_utf8(v) }
+    else
+      obj
+    end
   end
 
   def self.unsupported_iframe_src?(src)
@@ -448,7 +474,11 @@ module Percy
     return @percy_dom unless @percy_dom.nil?
 
     response = fetch('percy/dom.js')
-    @percy_dom = response.body
+    # Net::HTTP returns the body as ASCII-8BIT; the @percy/dom bundle contains
+    # non-ASCII bytes (valid UTF-8). Relabel as UTF-8 so selenium-webdriver can
+    # JSON-encode `execute_script(percy_dom_script)` without
+    # Encoding::UndefinedConversionError under the pure-Ruby JSON generator.
+    @percy_dom = response.body.dup.force_encoding(Encoding::UTF_8)
   end
 
   def self.log(msg, lvl = 'info')

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Percy
-  VERSION = '1.1.3-beta.0'.freeze
+  VERSION = '1.1.3-beta.1'.freeze
 end


### PR DESCRIPTION
## Problem
`percy_snapshot` fails on any page with non-ASCII content (em-dashes, smart quotes, emoji, even Google-Fonts CSSOM) with `Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8` → "Could not take DOM snapshot" → build finalizes empty. Found validating the PER-7348 readiness gate (every snapshot failed).

## Root cause
- `Net::HTTP` returns the **@percy/dom** bundle (`fetch_percy_dom`) as `ASCII-8BIT`.
- `selenium-webdriver` returns the **execute_script-serialized DOM** as `ASCII-8BIT`.
- Bytes are valid UTF-8, but JSON-encoding them (selenium's `execute_script` payload + the snapshot POST body) raises `Encoding::UndefinedConversionError` on the first multibyte byte under the pure-Ruby JSON generator. First failure is `execute_script(percy_dom_script)`, before serialize.

percy-capybara is unaffected (Capybara's `evaluate_script` normalises to UTF-8).

## Fix
`force_encoding('UTF-8')` (relabel, not transcode — bytes are already UTF-8):
1. `fetch_percy_dom` → the @percy/dom script.
2. recursive `force_utf8` over `dom_snapshot` before POST.

## Validation
Page with `…`/`✓` + Google Fonts + remote image: all 7 readiness snapshots post cleanly, gate timings intact (strict ~2.5s / fast ~110ms / balanced ~2.0s) — Percy build #871.

## Notes
- **Not a CLI issue** — raised Ruby-side before reaching the CLI.
- Most visible when json's C extension isn't active (pure-Ruby generator); fix makes the SDK robust regardless.
- Bumps version to `1.1.3-beta.1` for the beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)