### PR TITLE
release v1.1.3-beta.1

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Percy
-  VERSION = '1.1.3-beta.0'.freeze
+  VERSION = '1.1.3-beta.1'.freeze
 end


### PR DESCRIPTION
Bumps the SDK to the next beta (`1.1.3-beta.0` → `1.1.3-beta.1`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)